### PR TITLE
Added pt_BR translation

### DIFF
--- a/src/main/resources/assets/itfellfromthesky/lang/pt_BR
+++ b/src/main/resources/assets/itfellfromthesky/lang/pt_BR
@@ -1,0 +1,15 @@
+itemGroup.itfellfromthesky=It Fell From The Sky
+tile.compactPorkchop.name=Carne De Porco Compactada
+itfellfromthesky.desc_compactPorkchop1=Coloque e clique com o botão direito com uma estrela do nether
+itfellfromthesky.desc_compactPorkchop2=...ou descompacte-a.
+itfellfromthesky.desc_compactPorkchop3=Eu sou um subtítulo,
+itfellfromthesky.desc_compactPorkchop4=não um policial.
+itfellfromthesky.hailPigzilla.hail=Hail
+itfellfromthesky.hailPigzilla.hydra=Hydra
+itfellfromthesky.hailPigzilla.pigzilla= Pigzilla!
+itfellfromthesky.hailPigzilla.location=Ele está em  
+itfellfromthesky.summonRequiresOp=Você precisa ser Op para convocar o poderoso Pigzilla!
+itfellfromthesky.config.cat.gameplay.name=Gameplay
+itfellfromthesky.config.cat.gameplay.comment=Essas opções afetam o gameplay enquanto utilizando o mod.
+itfellfromthesky.config.prop.summonPigzillaNeedsOp.name=Convocar o Pigzilla nescessita de Op
+itfellfromthesky.config.prop.summonPigzillaNeedsOp.comment=É nescessario Op para convocar o Pigzilla?


### PR DESCRIPTION
Words that weren't translated ("gameplay" and "hail") don't have an exact translation to portuguese and are often used in english. For instance gameplay can be translated to "jogatina", but  few people use this word (we usually say gameplay) and it is not an 'exact translation'.
